### PR TITLE
build.sh script using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+
+RUN apt-get update
+
+RUN apt install -y texlive-xetex pandoc
+
+ADD . /src/
+WORKDIR /src/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ git clone https://github.com/steemit/bluepaper && cd blupaper
 
 Bluepaper.pdf should be created.
 
+## Ubuntu 16.04 or higher
 
-## Installation Instructions
+### Installation Instructions
 
 Install packages
 ```bash
@@ -30,9 +31,7 @@ Clone repository
 git clone https://github.com/steemit/bluepaper
 ```
 
-## Build Instructions
-
-### Ubuntu 16.04 or higher
+### Build Instructions
 
 Open the bluepaper directory
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 This repository contains the LaTeX source code for the Bluepaper. The instructions to clone the repository and build the PDF using pandoc are described below.
 
-Currently the build instructions are for Ubuntu 16.04 or higher. Eventually these will be expanded to use Docker and work on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build on a different OS.
+Currently the build instructions are for Ubuntu 16.04 or higher. There is also separate script, which build PDF using docker, which can be used on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build natively on a different OS.
+
+## Using docker
+
+First build will take a while, because docker image will need to be build. Next builds should be much faster :)
+
+```
+git clone https://github.com/steemit/bluepaper && cd blupaper
+./build.sh
+```
+
+Bluepaper.pdf should be created.
+
 
 ## Installation Instructions
 
@@ -19,6 +31,8 @@ git clone https://github.com/steemit/bluepaper
 ```
 
 ## Build Instructions
+
+### Ubuntu 16.04 or higher
 
 Open the bluepaper directory
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the LaTeX source code for the Bluepaper. The instructions to clone the repository and build the PDF using pandoc are described below.
 
-Currently the build instructions are for Ubuntu 16.04 or higher. There is also separate script, which will build the PDF using docker, that can be used on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build natively on a different OS.
+Currently the build instructions are for Ubuntu 16.04 or higher. There is also separate script, which will build the PDF using docker, and can be used on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build natively on a different OS.
 
 ## Using docker
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the LaTeX source code for the Bluepaper. The instructions to clone the repository and build the PDF using pandoc are described below.
 
-Currently the build instructions are for Ubuntu 16.04 or higher. There is also separate script, which build PDF using docker, which can be used on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build natively on a different OS.
+Currently the build instructions are for Ubuntu 16.04 or higher. There is also separate script, which will build the PDF using docker, that can be used on other operating systems. Users are welcome to try out the build in their local environments and submit a pull request to update the readme instructions if they are able to get it to successfully build natively on a different OS.
 
 ## Using docker
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+docker build -t pdfbuilder .
+
+CMD="pandoc Bluepaper.md --latex-engine=xelatex -o Bluepaper.pdf"
+
+docker run -v $(pwd):/src/ --entrypoint /src/entrypoint.sh pdfbuilder $CMD

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+TARGET_USER_GID=$(stat -c "%u" /src)
+useradd -m -s /bin/bash -u $TARGET_USER_GID builder
+
+COMMAND=$@
+su -c "$COMMAND" builder
+


### PR DESCRIPTION
Single command building process:

`./build.sh`

INFO: `entrypoint.sh` is added to solve a problem with users permissions. Without it pdf would always have wrong permissions:

```
22:22 $ ls -la
total 152
drwxrwxr-x  4 kszumny kszumny  4096 Sep  9 22:22 .
drwxrwxr-x 77 kszumny kszumny  4096 Sep  9 19:18 ..
-rw-rw-r--  1 kszumny kszumny 21227 Sep  9 20:10 Bluepaper.md
-rw-r--r--  1 root    root    93112 Sep  9 22:22 Bluepaper.pdf
-rwxrwxr-x  1 kszumny kszumny   164 Sep  9 22:22 build.sh
-rw-rw-r--  1 kszumny kszumny   161 Sep  9 22:22 Dockerfile
-rwxrwxr-x  1 kszumny kszumny   139 Sep  9 22:11 entrypoint.sh
drwxrwxr-x  8 kszumny kszumny  4096 Sep  9 22:22 .git
drwxrwxr-x  2 kszumny kszumny  4096 Sep  9 19:18 images
-rw-rw-r--  1 kszumny kszumny    36 Sep  9 19:47 missfont.log
-rw-rw-r--  1 kszumny kszumny   991 Sep  9 19:18 README.md
```